### PR TITLE
Fix incorrect JSON formatting with llama 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ typings/
 # TypeScript cache
 *.tsbuildinfo
 
+# Typescript declaration files
+*.d.ts
+
 # Optional npm cache directory
 .npm
 
@@ -56,6 +59,7 @@ typings/
 
 # Yarn Integrity file
 .yarn-integrity
+yarn.lock
 
 # dotenv environment variables file
 .env
@@ -94,3 +98,5 @@ out/
 # Ollama
 blobs/
 manifests/
+
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,6 @@ typings/
 # TypeScript cache
 *.tsbuildinfo
 
-# Typescript declaration files
-*.d.ts
-
 # Optional npm cache directory
 .npm
 

--- a/src/backend/services/ollama.ts
+++ b/src/backend/services/ollama.ts
@@ -153,7 +153,7 @@ export const askOllama = async (model: string, message: string) => {
       },
       {
         role: 'user',
-        content: `Now answer the following question in a formatted JSON with both the response and transaction fields deduced from the users question. If the user's question does not initiate a transaction, let the transaction be an empty object. Adhere strictly to JSON syntax. Question: ${message}. Response:`,
+        content: `Now answer the following question in a valid formatted JSON object without comments with both the response and transaction fields deduced from the users question. If the user's question does not initiate a transaction, let the transaction be an empty object. Adhere strictly to JSON syntax without comments. Question: ${message}. Response:`,
       },
     ],
   });

--- a/src/backend/services/prompts.ts
+++ b/src/backend/services/prompts.ts
@@ -1,23 +1,28 @@
 export const MOR_PROMPT = 
 `###System:
-You are MORPHEUS, an AI assistant, but you prefer to be called a SmartAgent. You respond to any question users may have and assist them in sending transactions with metamask by creating a valid transaction object. 
+You are MORPHEUS, an AI assistant, but you prefer to be called a SmartAgent. You respond to any question users may have and assist them in sending transactions 
+with metamask by creating a valid transaction object. 
 
 Keep your response short, using 2 or 3 sentences maximum.
 
-Respond in a valid JSON to be consumed by an application following this pattern:
+Respond in a valid JSON without comments to be consumed by an application following this pattern:
 {"response", "your response goes here", "transaction", "user transaction object goes here"}. 
-Only respond with the JSON, NEVER provide any text outside of the json. Your respond only in a valid JSON, nothing else. If the user wants to initate a transaction with their question, create a valid transaction object from the information in their question. If the user is not initating a transaction with their question let the transaction field be an empty object. Structure the object based off the type of transaction they want to intiate.
+Only respond with a JSON object without any comments, NEVER provide any text outside of the json. Your respond only in a valid JSON. 
+If the user wants to initate a transaction with their question, create a valid transaction JSON object from the information in their question. If the user is not initating a 
+transaction with their question let the transaction field be an empty object. Structure the object based off the type of transaction they want to intiate.
 
-For Transfer transactions create a transaction object following this pattern:
+For Transfer transactions create a JSON transaction object without any comments even on missing data following this pattern:
 {"type": "Transfer":, "targetAddress": "target address goes here", "ethAmount": "amount of eth to transfer goes here"}
 
 For Balance transactions create a transaction object following this pattern:
 {"type": "Balance"}
 
-Here are examples on how to create the transaction object from the user's question:
+If there are comments in the format, please remove them before returning the JSON object.
+
+Here are examples on how to create the transaction object from the question:
 ###Examples:
-Example 1:
-Question: "transfer 43 eth to 0x223738a369F0804c091e13740D26D1269294bc1b", //User is initiating a transfer transaction with their question.
+Example 1: User is initiating a transfer transaction with their question.
+Question: "transfer 43 eth to 0x223738a369F0804c091e13740D26D1269294bc1b",
 Response: "{
     "response": "Of course! The transaction details are prepared for you. Please double-check the parameters before confirming on Metamask.",
     "transaction": {
@@ -26,8 +31,8 @@ Response: "{
         "ethAmount": "43"
     }
 }"
-Example 2:
-Question: "balance?" //User is intiating a balance transaction with their question
+Example 2: User is intiating a balance transaction with their question
+Question: "balance?" 
 Response: "{
     "response": "",
     "transaction": { 
@@ -35,8 +40,8 @@ Response: "{
     }
 }"
 
-Example 3:
-Question: "Hey Morpheus, whats my balance?" //User is intiating a balance transaction with their question
+Example 3: User is intiating a balance transaction with their question
+Question: "Hey Morpheus, whats my balance?"
 Response: "{
     "response": "",
     "transaction": { 
@@ -44,8 +49,8 @@ Response: "{
     }
 }"
 
-Example 3:
-Question: "how much eth do i have?" //User is intiating a balance transaction with their question 
+Example 3: User is intiating a balance transaction with their question 
+Question: "how much eth do i have?" 
 Response: "{
     "response": "",
     "transaction": { 
@@ -53,37 +58,40 @@ Response: "{
     }
 }"
 
-Example 4:
-Question: "Why is the sky blue"  //the user's question does not initiate a transaction, let the transaction be an empty object.
+Example 4: question does not initiate a transaction, let the transaction be an empty object.
+Question: "Why is the sky blue"  
 Response: "{
-    "response": "The sky is blue because of a thing called Rayleigh scattering. When sunlight enters the Earth's atmosphere, it hits air and other tiny particles. This light is made of many colors. Blue light scatters more because it travels as shorter, smaller waves. So, when we look up, we see more blue light than other colors.",
+    "response": "The sky is blue because of a thing called Rayleigh scattering. When sunlight enters the Earth\'s atmosphere, it hits air and other tiny particles. This light is made of many colors. Blue light scatters more because it travels as shorter, smaller waves. So, when we look up, we see more blue light than other colors.",
     "transaction": {} 
 }"
 
 
 
-Example 5: 
-Question: "What is stETH" //the user's question does not initiate a transaction, let the transaction be an empty object..
+Example 5: question does not initiate a transaction, let the transaction be an empty object..
+Question: "What is stETH" 
 Response: "{
     "response": "stETH stands for staked Ether. It's a type of cryptocurrency. When people stake their Ether (ETH) in a blockchain network to support it, they get stETH in return. This shows they have ETH locked up, and they can still use stETH in other crypto activities while earning rewards.",
     "transaction": {} 
     }
 
-Example 6: 
-Question: "transfer" //sufficient information in the user's question to create a valid transaction object. If the question does not provide enough information for a transaction, let the transaction field be an empty object.
+Example 6: sufficient information in the question to create a valid transaction object. If the question does not provide enough information for a transaction, let the transaction field be an empty object.
+Question: "transfer" 
 Response: "{
     "response": "I can certainly help you transfer ethereum, However, i needthe eth amount and target address",
     "transaction": {} 
     }
 
-For Transfer transactions, ensure that there is sufficient information in the user's question to create a valid transaction object. If the question does not provide enough information for a transaction, do not include a transaction object in the response.
+For Transfer transactions, ensure that there is sufficient information in the question to create a valid transaction object. If the question does not provide enough information for a transaction, do not include a transaction object in the response.
 `;
 
 export const errorHandling = `If a question is initiating a buy or transfer transaction and the user doesn't specify an amount in ETH. Gently decline to send the transaction
 and request the amount to buy or transfer (depending on their transaction type) in ethereum. 
 
 If a question is initiating a sell transaction and the user doesn't specify an amount in tokens. Gently decline to send the transaction
-and request the amount to sell in tokens. `;
+and request the amount to sell in tokens.
+
+In your response, if you do generate a transaction JSON object, never include any comments in the JSON format you return back.
+`;
 //TODO: allow for staking MOR and swap tokens
 //TODO: use RAG to include a database to tokenAddresses and symbols
 //TODO: include chat history

--- a/src/frontend/utils/utils.ts
+++ b/src/frontend/utils/utils.ts
@@ -4,6 +4,9 @@ import { ModelResponse } from './types';
 export const parseResponse = (jsonString: string) => {
   // Assert the type of the parsed object.
   console.log(jsonString)
+  // uses regex to remove comments that llama sometimes includes in the JSON string
+  // ranges from // to the end of the line or the end of the string
+  jsonString = jsonString.replace(/(?<!\\)\/\/.*?(?=\n|$)/gm, ""); 
   let parsed: string
   try {
     parsed = JSON.parse(jsonString);
@@ -13,7 +16,7 @@ export const parseResponse = (jsonString: string) => {
       parsed = JSON.parse(jsonString);
     } catch(error){
       new Error("Ollama error")
-      return {response: "error", transaction: {}}
+      return {response: "error", transaction: {}};
     }
   }
 


### PR DESCRIPTION
For some reason llama will try to be helpful and include a comment in the JSON format it returns which causes parsing issues (despite the best effort to tell it not to include any JSON comments). Added regex to replace everything from "//" to "\n" to ensure that we can properly parse the string to form a valid JSON.

Also updated the prompt to remove any "'" as that caused parsing problems (though removing the comments should fix it too)

From testing we no longer error out and continue on to try and send a transaction. Further work will be needed to maintain state on the data passed to the user.

Also as an extra, updated the gitignore to ignore some generated files.