### PR TITLE
[UX Fix] Improve chat layout/UX with auto scroll and input focus

### DIFF
--- a/src/frontend/components/layout/main.tsx
+++ b/src/frontend/components/layout/main.tsx
@@ -38,11 +38,13 @@ const Main = {
     display: flex;
     width: 100%;
     height: ${(props) => props.theme.layout.topBarHeight}px;
+    flex-shrink: 0;
   `,
   MainWrapper: Styled.div`
     display: flex;
     width: 80%;
     height: 70%;
+    flex-grow: 1;
     border-radius: 30px;
     border: 5px solid ${(props) => props.theme.colors.hunter};
     padding: 10px;
@@ -50,6 +52,7 @@ const Main = {
   BottomWrapper: Styled.div`
     display: flex;
     width: 100%;
-    height: 20%;
+    height:  ${(props) => props.theme.layout.bottomBarHeight}px;
+    flex-shrink: 0;
   `,
 };

--- a/src/frontend/theme/theme.ts
+++ b/src/frontend/theme/theme.ts
@@ -8,6 +8,7 @@ export interface ITheme {
   };
   layout: {
     topBarHeight: number;
+    bottomBarHeight: number;
   };
   fonts: {
     family: {
@@ -38,8 +39,8 @@ const common = {
     balance: '#FFFFFF',
   },
   layout: {
-    leftBarWidth: 200,
     topBarHeight: 130,
+    bottomBarHeight: 130,
   },
   fonts: {
     size: {

--- a/src/frontend/views/chat.tsx
+++ b/src/frontend/views/chat.tsx
@@ -1,5 +1,5 @@
 // libs
-import React, { FormEvent, useEffect, useState } from 'react';
+import React, { FormEvent, useEffect, useState, useRef } from 'react';
 import Styled from 'styled-components';
 import { useSDK } from '@metamask/sdk-react';
 import { ThreeDots } from 'react-loader-spinner';
@@ -28,6 +28,9 @@ const ChatView = (): JSX.Element => {
   const ethInWei = '1000000000000000000';
   const [selectedNetwork, setSelectedNetwork] = useState('');
 
+  const chatMainRef = useRef<HTMLDivElement>(null);
+  const chatInputRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     window.backendBridge.ollama.onAnswer((response) => {
       setDialogueEntries([
@@ -42,6 +45,32 @@ const ChatView = (): JSX.Element => {
       window.backendBridge.removeAllListeners(OllamaChannel.OllamaAnswer);
     };
   });
+
+  // Scroll to bottom of chat when user adds new dialogue
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (chatMainRef.current && mutation.type === 'childList') {
+          chatMainRef.current.scrollTop = chatMainRef.current.scrollHeight;
+        }
+      }
+    });
+
+    if (chatMainRef.current) {
+      observer.observe(chatMainRef?.current, {
+        childList: true, // observe direct children
+      });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  // Refocus onto input field once new dialogue entry is added
+  useEffect(() => {
+    if (chatInputRef.current) {
+      chatInputRef.current.focus();
+    }
+  }, [dialogueEntries]);
 
   //Function to update dialogue entries
   const updateDialogueEntries = (question: string, message: string) => {
@@ -211,7 +240,7 @@ const ChatView = (): JSX.Element => {
         <option value="0xa4b1">Arbitrum</option>
         <option value="0x64">Gnosis</option>
       </Chat.Dropdown>
-      <Chat.Main>
+      <Chat.Main ref={chatMainRef}>
         {dialogueEntries.map((entry, index) => {
           return (
             <Chat.QuestionWrapper
@@ -236,6 +265,7 @@ const ChatView = (): JSX.Element => {
         <Chat.InputWrapper>
           <Chat.Arrow>&gt;</Chat.Arrow>
           <Chat.Input
+            ref={chatInputRef}
             disabled={isOllamaBeingPolled}
             value={inputValue}
             onChange={handleQuestionChange}


### PR DESCRIPTION
This PR contains the following improvements:

- scroll to bottom of chat automatically when content is added to chat
- autofocus on input after response is returned so that user doesn't have to manually click on input again
- nit fixes to chat layout

Before:

https://github.com/MorpheusAIs/Node/assets/1245963/3eef46ef-3cf2-4c22-a301-d255498f8d7f


After:


https://github.com/MorpheusAIs/Node/assets/1245963/15f588b9-7c43-40f4-8574-564463364606

