### PR TITLE
[UI Nits] Avoid covering text with button + handle overflow

### DIFF
--- a/src/frontend/components/layout/main.tsx
+++ b/src/frontend/components/layout/main.tsx
@@ -43,7 +43,7 @@ const Main = {
   MainWrapper: Styled.div`
     display: flex;
     width: 80%;
-    height: 70%;
+    max-width: 850px;
     flex-grow: 1;
     border-radius: 30px;
     border: 5px solid ${(props) => props.theme.colors.hunter};

--- a/src/frontend/views/chat.tsx
+++ b/src/frontend/views/chat.tsx
@@ -313,10 +313,10 @@ const Chat = {
     margin-bottom: 20px;
   `,
   Question: Styled.span`
-    display: flex;
     color: ${(props) => props.theme.colors.notice};
     font-family: ${(props) => props.theme.fonts.family.primary.regular};
     font-size: ${(props) => props.theme.fonts.size.small};
+    word-wrap: break-word;
     margin-bottom: 5px;
   `,
   Answer: Styled.span`
@@ -348,7 +348,7 @@ const Chat = {
     width: 100%;
     height: 40px;
     border-radius: 30px;
-    padding: 0 25px;
+    padding: 0 40px 0 25px;
     background: ${(props) => props.theme.colors.core};
     border: 2px solid ${(props) => props.theme.colors.hunter};
     color: ${(props) => props.theme.colors.notice};


### PR DESCRIPTION
This PR allows for the following fixes:

- Max width for chat
- Extra padding for so input won’t be covered by input button
- Extremely long words will wrap instead of overflow

Before:


https://github.com/MorpheusAIs/Node/assets/1245963/5e98e5ba-15eb-4e92-a043-fddbe740def3

After:


https://github.com/MorpheusAIs/Node/assets/1245963/23705384-93c8-4406-a38d-31686a8a71dc

