### PR TITLE
Fixes an issue with the QR code modal being able to be toggled via the connect wallet button

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -119,8 +119,6 @@ const AppRoot = () => {
 
                   return {
                     mount: () => {
-                      if (modalContainer) return;
-
                       modalContainer = document.createElement('div');
 
                       modalContainer.id = 'meta-mask-modal-container';


### PR DESCRIPTION
Fixes a bug I noticed where exiting out of the `QrCodeModal` when clicking the `connect` button doesn't allow for it to be reshown on subsequent `connect` button clicks. (See before vs after).

Early return for the `modalContainer` DOM element shouldn't be necessary since at `unmount` we ensure that the `modalContainer` element is removed.

## Before
https://github.com/MorpheusAIs/Node/assets/7267304/264511c8-fe85-4e6e-b37b-dcb212ff7f4a

## After
https://github.com/MorpheusAIs/Node/assets/7267304/d11ca7c0-f740-4aca-8e0f-c4b5d2fa49d3

