### PR TITLE
[UI/UX Fix] Show network dropdown if the wallet is connected

### DIFF
--- a/src/frontend/components/buttons/connect-wallet-button.tsx
+++ b/src/frontend/components/buttons/connect-wallet-button.tsx
@@ -59,7 +59,6 @@ const ConnectWalletButton = {
     font-family: ${(props) => props.theme.fonts.family.primary.regular};
     font-size: ${(props) => props.theme.fonts.size.small};
     color: ${(props) => props.theme.colors.notice};
-    margin-right: 10px;
   `,
   Badge: Styled.div<BadgeProps>`
     display: flex;

--- a/src/frontend/views/chat.tsx
+++ b/src/frontend/views/chat.tsx
@@ -199,6 +199,9 @@ const ChatView = (): JSX.Element => {
   const handleNetworkChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedChain = e.target.value;
 
+    const selectedValue = e.target.value;
+    setSelectedNetwork(selectedValue);
+
     // Check if the default option is selected
     if (!selectedChain) {
       console.log('No network selected.');
@@ -235,7 +238,7 @@ const ChatView = (): JSX.Element => {
   return (
     <Chat.Layout>
       {connected && (
-        <Chat.Dropdown onChange={handleNetworkChange} value="">
+        <Chat.Dropdown onChange={handleNetworkChange} value={selectedNetwork}>
           <option value="">Select a network</option>
           <option value="0x1">Ethereum</option>
           <option value="0xaa36a7">Sepolia</option>

--- a/src/frontend/views/chat.tsx
+++ b/src/frontend/views/chat.tsx
@@ -234,13 +234,15 @@ const ChatView = (): JSX.Element => {
 
   return (
     <Chat.Layout>
-      <Chat.Dropdown onChange={handleNetworkChange} value="">
-        <option value="">Select a network</option>
-        <option value="0x1">Ethereum</option>
-        <option value="0xaa36a7">Sepolia</option>
-        <option value="0xa4b1">Arbitrum</option>
-        <option value="0x64">Gnosis</option>
-      </Chat.Dropdown>
+      {connected && (
+        <Chat.Dropdown onChange={handleNetworkChange} value="">
+          <option value="">Select a network</option>
+          <option value="0x1">Ethereum</option>
+          <option value="0xaa36a7">Sepolia</option>
+          <option value="0xa4b1">Arbitrum</option>
+          <option value="0x64">Gnosis</option>
+        </Chat.Dropdown>
+      )}
       <Chat.Main ref={chatMainRef}>
         {dialogueEntries.map((entry, index) => {
           return (
@@ -355,6 +357,9 @@ const Chat = {
     color: ${(props) => props.theme.colors.notice};
     font-family: ${(props) => props.theme.fonts.family.primary.regular};
     font-size: ${(props) => props.theme.fonts.size.small};
+    &:focus {
+      border: 2px solid ${(props) => props.theme.colors.emerald};
+    }
   `,
   Arrow: Styled.span`
     display: flex;


### PR DESCRIPTION
This PR includes following changes:

- show network dropdown if the wallet is connected
- input focus change border color
- update network dropdown value to selected chain
- connect button - remove margin right


**Before:**

https://github.com/MorpheusAIs/Node/assets/68545109/478a0e2f-05e0-4bbc-b7a9-507382d21503

**After:**

https://github.com/MorpheusAIs/Node/assets/68545109/4a869424-9ca6-43a1-8447-75049223b084

