### PR TITLE
Fix build error of macos-alias package on macOS silicon

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9207,9 +9207,9 @@ multiformats@^9.4.2:
     imul "^1.0.0"
 
 nan@^2.4.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
-  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
+  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
 nanoid@^3.3.6, nanoid@^3.3.7:
   version "3.3.7"


### PR DESCRIPTION
I ran into  macos-alias npm package build error while trying to build on macosx silicon (M1/M2/M3).

Updating the macos-alias's dependency version to latest fixed the build.